### PR TITLE
ENH: Adds selective hyperparameter optimization

### DIFF
--- a/docs/available_models.md
+++ b/docs/available_models.md
@@ -4,15 +4,115 @@ This document contains a list of all the models available in the _ageml_ package
 
 ## Model List
 
-- [Linear Regression](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LinearRegression.html) (`linear_reg` in ageml)
+- [Linear Regression](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LinearRegression.html) (`linear_reg` in `ageml`)
   - __Hyperparameters__: None</br></br>
-- [Ridge Regression](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.Ridge.html) (`ridge` in ageml)
+- [Ridge Regression](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.Ridge.html) (`ridge` in `ageml`)
   - __Hyperparameters__: `alpha`</br></br>
-- [Lasso Regression](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.Lasso.html) (`lasso` in ageml)
+- [Lasso Regression](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.Lasso.html) (`lasso` in `ageml`)
   - __Hyperparameters__: `alpha`</br></br>
-- [XGBoost Regression](https://xgboost.readthedocs.io/en/latest/python/python_api.html#module-xgboost.sklearn) (`xgboost` in ageml)
+- [XGBoost Regression](https://xgboost.readthedocs.io/en/latest/python/python_api.html#module-xgboost.sklearn) (`xgboost` in `ageml`)
   - __Hyperparameters__: `eta`, `gamma`, `max_depth`, `min_child_weight`, `max_delta_step`, `subsample`, `colsample_bytree`, `colsample_bylevel`, `colsample_bynode`, `lambda`, `alpha`</br></br>
-- [Epsilon-Support Vector Regression](https://scikit-learn.org/stable/modules/generated/sklearn.svm.SVR.html#sklearn.svm.SVR) (`linear_svr` in ageml)
+- [Epsilon-Support Vector Regression](https://scikit-learn.org/stable/modules/generated/sklearn.svm.SVR.html#sklearn.svm.SVR) (`linear_svr` in `ageml`)
   - __Hyperparameters__: `C`, `epsilon`</br></br>
-- [Random Forest Regression](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestRegressor.html) (`rf` in ageml)
+- [Random Forest Regression](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestRegressor.html) (`rf` in `ageml`)
   - __Hyperparameters__: `n_estimators`, `max_depth`, `min_samples_split`, `min_samples_leaf`, `max_features`, `min_impurity_decrease`, `max_leaf_nodes`, `min_weight_fraction_leaf`
+
+
+### Model Hyperparameters
+
+When specifying model hyperparameter ranges, be aware that a log operation can be applied to some of them, aligned to the `scikit-learn` API. See the table below for reference of the hyperparameters that have this constraint explicitly implemented in `ageml` (or alternatively, import and print the `AgeML.model_hyperparameter_types` dictionary):
+<table>
+  <tr>
+    <th>Model</th>
+    <th>Parameter</th>
+    <th>Type</th>
+  </tr>
+  <tr>
+    <td rowspan="1">Lasso Regression</td>
+    <td>alpha</td>
+    <td>log</td>
+  </tr>
+  <tr>
+    <td rowspan="2">Epsilon-Support Vector Regression</td>
+    <td>C</td>
+    <td>log</td>
+  </tr>
+  <tr>
+    <td>epsilon</td>
+    <td>log</td>
+  </tr>
+  <tr>
+    <td rowspan="11">XGBoost Regression</td>
+    <td>eta</td>
+    <td>float</td>
+  </tr>
+  <tr>
+    <td>gamma</td>
+    <td>float</td>
+  </tr>
+  <tr>
+    <td>max_depth</td>
+    <td>int</td>
+  </tr>
+  <tr>
+    <td>min_child_weight</td>
+    <td>int</td>
+  </tr>
+  <tr>
+    <td>max_delta_step</td>
+    <td>int</td>
+  </tr>
+  <tr>
+    <td>subsample</td>
+    <td>float</td>
+  </tr>
+  <tr>
+    <td>colsample_bytree</td>
+    <td>float</td>
+  </tr>
+  <tr>
+    <td>colsample_bylevel</td>
+    <td>float</td>
+  </tr>
+  <tr>
+    <td>colsample_bynode</td>
+    <td>float</td>
+  </tr>
+  <tr>
+    <td>lambda</td>
+    <td>log</td>
+  </tr>
+  <tr>
+    <td>alpha</td>
+    <td>log</td>
+  </tr>
+  <tr>
+    <td rowspan="9">Random Forest Regression</td>
+    <td>n_estimators</td>
+    <td>int</td>
+  </tr>
+  <tr>
+    <td>max_depth</td>
+    <td>int</td>
+  </tr>
+  <tr>
+    <td>min_samples_split</td>
+    <td>int</td>
+  </tr>
+  <tr>
+    <td>min_samples_leaf</td>
+    <td>int</td>
+  </tr>
+  <tr>
+    <td>max_features</td>
+    <td>int</td>
+  </tr>
+  <tr>
+    <td>min_impurity_decrease</td>
+    <td>log</td>
+  </tr>
+  <tr>
+    <td>max_leaf_nodes</td>
+    <td>int</td>
+  </tr>
+</table>

--- a/docs/available_models.md
+++ b/docs/available_models.md
@@ -1,6 +1,6 @@
 # Available Models in ageml
 
-This document contains a list of all the models available in the _ageml_ package, with a list of the hyperparameters that are optimized in _ageml_ (if specified to do so) and a link to their corresponding documentation. The majority of them come from the [scikit-learn](https://scikit-learn.org/stable/) package.
+This document contains a list of all the models available in the _ageml_ package, with a list of the hyperparameters that are optimized in _ageml_ (if specified to do so) and a link to their corresponding documentation. Hyperparameter optimization is done respect to the Mean Absolute Error (MAE). The majority of them come from the [scikit-learn](https://scikit-learn.org/stable/) package.
 
 ## Model List
 

--- a/src/ageml/messages.py
+++ b/src/ageml/messages.py
@@ -109,7 +109,10 @@ poly_feature_extension_description = (
 hyperparameter_grid_description = (
     "Number of points for which the hyperparameter optimization Grid Search will train\n"
     "a model, and parameter ranges to sample from. An integer is required, followed \n"
-    "by the parameters to optimize. (e.g.   -ht 100  C=1,2,3  kernel=linear,rbf)"
+    "by the parameters to optimize. (e.g.   -ht 10  C=1,3  kernel=linear,rbf)\n"
+    "For more information on how to specify the hyperparameter ranges, refer to the \n"
+    "documentation in the ageml repository:\n"
+    "https://github.com/compneurobilbao/ageml/tree/main/docs/available_models.md#model-hyperparameters"
 )
 
 thr_long_description = "Threshold for classification. Default: 0.5 \n" "The threshold is used for assingning hard labels. (e.g. --thr 0.5)"

--- a/src/ageml/messages.py
+++ b/src/ageml/messages.py
@@ -108,8 +108,8 @@ poly_feature_extension_description = (
 
 hyperparameter_grid_description = (
     "Number of points for which the hyperparameter optimization Grid Search will train\n"
-    "a model. The parameter ranges are predefined. An integer is required.\n"
-    "(e.g.   -ht 100   /   --hyperparameter_tuning 100)"
+    "a model, and parameter ranges to sample from. An integer is required, followed \n"
+    "by the parameters to optimize. (e.g.   -ht 100  C=1,2,3  kernel=linear,rbf)"
 )
 
 thr_long_description = "Threshold for classification. Default: 0.5 \n" "The threshold is used for assingning hard labels. (e.g. --thr 0.5)"

--- a/src/ageml/modelling.py
+++ b/src/ageml/modelling.py
@@ -443,7 +443,7 @@ class AgeML:
                 print(f"Best pipeline:\n{self.pipeline}")
 
             # CV Summary of the selected hyperparameters
-            print("\nSummary metrics of the best CV split for the best hyperparameters:")
+            print("\nSummary metrics of the CV splits for the best hyperparameters:")
             summary_train = self.summary_metrics(best_split_metrics_train)
             print("Train: MAE %.2f ± %.2f, RMSE %.2f ± %.2f, R2 %.3f ± %.3f, p %.3f ± %.3f" % tuple(summary_train))
             summary_test = self.summary_metrics(best_split_metrics_test)

--- a/src/ageml/modelling.py
+++ b/src/ageml/modelling.py
@@ -8,6 +8,8 @@ AgeML - able to fit age models and predict age.
 Classifier - classifier of class labels based on deltas.
 """
 
+import copy
+
 import numpy as np
 import scipy.stats as st
 from xgboost import XGBRegressor
@@ -35,7 +37,6 @@ from hyperopt import tpe
 
 
 class AgeML:
-
     """Able to fit age models and predict age.
 
     This class allows the set up the pipeline for age modelling, to
@@ -173,6 +174,7 @@ class AgeML:
         CV_split,
         seed,
         hyperparameter_tuning: int = 0,
+        hyperparameter_params: dict = {},
         feature_extension: int = 0,
     ):
         """Initialise variables."""
@@ -186,6 +188,7 @@ class AgeML:
         self.model_dict = AgeML.model_dict
         # Hyperparameters and feature extension
         self.hyperparameter_tuning = hyperparameter_tuning
+        self.hyperparameter_params = hyperparameter_params
         self.feature_extension = feature_extension
 
         # Set required modelling parts
@@ -206,26 +209,22 @@ class AgeML:
             dict: dictionary with the hyperparameter grid
         """
         param_grid = {}
-        conditions = [self.model_type in AgeML.model_dict.keys(),
-                      self.hyperparameter_tuning > 0,
-                      not self.model_type == "hyperopt"]
+        conditions = [self.model_type in AgeML.model_dict.keys(), self.hyperparameter_tuning > 0, self.model_type != "hyperopt"]
         if all(conditions):
-            hyperparam_ranges = AgeML.model_hyperparameter_ranges[self.model_type]
             hyperparam_types = AgeML.model_hyperparameter_types[self.model_type]
+            invalid_hyperparams = [param for param in self.hyperparameter_params.keys() if param not in hyperparam_types.keys()]
+            if len(invalid_hyperparams) > 0:
+                raise ValueError(f"Hyperparameter(s) {invalid_hyperparams} not available for the selected model '{self.model_type}'.")
+
             # Initialize output grid
-            for hyperparam_name in list(hyperparam_types.keys()):
-                bounds = hyperparam_ranges[hyperparam_name]
-                if hyperparam_types[hyperparam_name] == 'log':
-                    param_grid[f"model__{hyperparam_name}"] = np.logspace(bounds[0],
-                                                                          bounds[1],
-                                                                          int(self.hyperparameter_tuning))
-                elif hyperparam_types[hyperparam_name] == 'int':
-                    param_grid[f"model__{hyperparam_name}"] = np.rint(np.linspace(bounds[0], bounds[1],
-                                                                      int(self.hyperparameter_tuning))).astype(int)
-                elif hyperparam_types[hyperparam_name] == 'float':
-                    param_grid[f"model__{hyperparam_name}"] = np.linspace(bounds[0],
-                                                                          bounds[1],
-                                                                          int(self.hyperparameter_tuning))
+            for hyperparam_name in list(self.hyperparameter_params.keys()):
+                low, high = self.hyperparameter_params[hyperparam_name]
+                if hyperparam_types[hyperparam_name] == "log":
+                    param_grid[f"model__{hyperparam_name}"] = np.logspace(low, high, int(self.hyperparameter_tuning))
+                elif hyperparam_types[hyperparam_name] == "int":
+                    param_grid[f"model__{hyperparam_name}"] = np.rint(np.linspace(low, high, int(self.hyperparameter_tuning))).astype(int)
+                elif hyperparam_types[hyperparam_name] == "float":
+                    param_grid[f"model__{hyperparam_name}"] = np.linspace(low, high, int(self.hyperparameter_tuning))
         self.hyperparameter_grid = param_grid
 
     def set_scaler(self, norm, **kwargs):
@@ -256,10 +255,11 @@ class AgeML:
         if model_type not in self.model_dict.keys():
             raise ValueError(f"Must select an available model type. Available: {list(self.model_dict.keys())}")
         elif model_type == "hyperopt":
-            self.model = HyperoptEstimator(regressor=any_regressor('age_regressor'),
-                                           preprocessing=any_preprocessing('age_preprocessing'),
-                                           algo=tpe.suggest,
-                                           )
+            self.model = HyperoptEstimator(
+                regressor=any_regressor("age_regressor"),
+                preprocessing=any_preprocessing("age_preprocessing"),
+                algo=tpe.suggest,
+            )
         else:
             self.model = self.model_dict[model_type](**kwargs)
 
@@ -304,11 +304,11 @@ class AgeML:
         y_true: 1D-Array with true ages; shape=n
         y_pred: 1D-Array with predicted ages; shape=n"""
 
-        MAE = metrics.mean_absolute_error(y_true, y_pred)
+        mae = metrics.mean_absolute_error(y_true, y_pred)
         rmse = metrics.mean_squared_error(y_true, y_pred, squared=False)
         r2 = metrics.r2_score(y_true, y_pred)
         p, _ = stats.pearsonr(y_true, y_pred)
-        return MAE, rmse, r2, p
+        return mae, rmse, r2, p
 
     def summary_metrics(self, array):
         """Calculates mean and standard deviations of metrics.
@@ -367,105 +367,127 @@ class AgeML:
         if self.pipeline is None and self.model_type != "hyperopt":
             raise TypeError("Must set a valid pipeline before running fit.")
 
-        # Variables of interes
-        pred_age = np.zeros(y.shape)
-        corrected_age = np.zeros(y.shape)
-        metrics_train = []
-        metrics_test = []
+        if self.model_type != "hyperopt":
+            # Optimize hyperparameters if required
+            if self.hyperparameter_tuning > 0:
+                print("Running Hyperparameter optimization...")
+            else:
+                print("No hyperparameter optimization will be done.")
+            # Generate the hyperparameter grid. If {}, default values are used
+            hyperparameter_grid = model_selection.ParameterGrid(self.hyperparameter_grid)
+            pipelines = []
+            # Generate pipelines with different hyperparameters from the grid
+            for grid_point in hyperparameter_grid:
+                original_pipeline = copy.deepcopy(self.pipeline)
+                point_pipeline = original_pipeline.set_params(**grid_point)
+                pipelines.append(point_pipeline)
+            # Variables of interest
+            pred_age = np.zeros([y.shape[0], len(pipelines)])
+            corrected_age = np.zeros([y.shape[0], len(pipelines)])
+            mae_means_test = []
+            # Loop through the pipelines, and then loop through the CV splits
+            for i_p, cv_pipeline in enumerate(pipelines):
+                print(f"\nRunning CV splits with pipeline:\n{cv_pipeline}")
+                split_metrics_train = []
+                split_metrics_test = []
+                kf_hyperopt = model_selection.KFold(n_splits=self.CV_split, random_state=self.seed, shuffle=True)
+                for i, (train, test) in enumerate(kf_hyperopt.split(X)):
+                    X_train, X_test = X[train], X[test]
+                    y_train, y_test = y[train], y[test]
 
-        # Optimize hyperparameters if required
-        if self.hyperparameter_grid != {}:
-            print("Running Hyperparameter optimization...")
-            opt_pipeline = model_selection.GridSearchCV(self.pipeline,
-                                                        self.hyperparameter_grid,
-                                                        cv=self.CV_split,
-                                                        scoring="neg_mean_absolute_error")
-            opt_pipeline.fit(X, y)
-            print(f"Hyperoptimization best parameters: {opt_pipeline.best_params_}")
-            # Set best parameters in pipeline
-            self.pipeline.set_params(**opt_pipeline.best_params_)
+                    # Train model with the hyperparameters
+                    cv_pipeline.fit(X_train, y_train)
+
+                    # Predictions on train and test set
+                    y_pred_train = cv_pipeline.predict(X_train)
+                    y_pred_test = cv_pipeline.predict(X_test)
+
+                    # Metrics in Train and Test sets
+                    split_metrics_train.append(self.calculate_metrics(y_train, y_pred_train))
+                    split_metrics_test.append(self.calculate_metrics(y_test, y_pred_test))
+
+                    # Print metrics
+                    print("\nFold N: %d" % (i + 1))
+                    print("Train: MAE %.2f, RMSE %.2f, R2 %.3f, p %.3f" % split_metrics_train[i])
+                    print("Test: MAE %.2f, RMSE %.2f, R2 %.3f, p %.3f" % split_metrics_test[i])
+
+                    # Fit and apply age-bias correction
+                    self.fit_age_bias(y_train, y_pred_train)
+                    y_pred_test_no_bias = self.predict_age_bias(y_test, y_pred_test)
+
+                    # Save results of hold out
+                    pred_age[test, i_p] = y_pred_test
+                    corrected_age[test, i_p] = y_pred_test_no_bias
+
+                # Compute the mean of scores over all CV splits
+                mean_score_test = np.mean(split_metrics_test, axis=0)[0]  # Mean of MAE
+                mae_means_test.append(mean_score_test)
+
+                # CV Summary of the selected hyperparameters
+                print("\nSummary metrics over all CV splits:")
+                summary_train = self.summary_metrics(split_metrics_train)
+                print("Train: MAE %.2f ± %.2f, RMSE %.2f ± %.2f, R2 %.3f ± %.3f, p %.3f ± %.3f" % tuple(summary_train))
+                summary_test = self.summary_metrics(split_metrics_test)
+                print("Test: MAE %.2f ± %.2f, RMSE %.2f ± %.2f, R2 %.3f ± %.3f, p %.3f ± %.3f" % tuple(summary_test))
+
+            # Select the best pipeline based on the mean scores
+            best_hyperparam_index = np.argmin(mae_means_test)
+            self.pipeline = pipelines[best_hyperparam_index]
+
+            # Get the predicted and corrected age of the best pipeline
+            pred_age = pred_age[:, best_hyperparam_index]
+            corrected_age = corrected_age[:, best_hyperparam_index]
+
+            if self.hyperparameter_tuning > 0:
+                print(f"\nHyperoptimization best parameters: {hyperparameter_grid[best_hyperparam_index]}")
+                print(f"Best pipeline:\n{self.pipeline}")
 
         elif self.model_type == "hyperopt":
             print("Running Hyperparameter optimization with 'hyperopt' model option...")
-            # Manual KFold
-            kf = model_selection.KFold(n_splits=self.CV_split,
-                                       random_state=self.seed,
-                                       shuffle=True)
-            best_models = []
-            best_preprocs = []
-            scores = []
-            
-            for i, (train_index, test_index) in enumerate(kf.split(X)):
-                print(f"\n---Hyperoptimization CV fold {i+1}/{self.CV_split}---\n")
-                X_train, X_val = X[train_index], X[test_index]
-                y_train, y_val = y[train_index], y[test_index]
-                # Fit
-                self.model.fit(X_train, y_train)
-                best_model = self.model.best_model()['learner']
-                best_preprocessing = self.model.best_model()['preprocs']
-                # Evaluate on validation set
-                pipe = [(f"preproc_{i}", preproc) for i, preproc in enumerate(best_preprocessing)]
-                pipe.append(("model", best_model))
-                temp_pipeline = pipeline.Pipeline(pipe)
-                score = temp_pipeline.score(X_val, y_val)
-                # Store best model, preproc, and score
-                best_models.append(best_model)
-                best_preprocs.append(best_preprocessing)
-                scores.append(score)
-            # Select the best model based on validation scores
-            best_index = np.argmax(scores)
-            best_model = best_models[best_index]
-            best_preprocessing = best_preprocs[best_index]
-            # Set the best model and preprocessing in the pipeline
+
+            # Variables of interest
+            pred_age = np.zeros(y.shape)
+            corrected_age = np.zeros(y.shape)
+
+            # Get the data split
+            X_train = X[self.train_indices,]
+            y_train = y[self.train_indices]
+            X_test = X[self.test_indices,]
+            y_test = y[self.test_indices]
+
+            # Fit the hyperopt model and compute loss
+            self.model.fit(X_train, y_train)
+            y_pred_train = self.model.predict(X_train)
+            y_pred_test = self.model.predict(X_test)
+            mae_train, rmse_train, r2_train, p_train = self.calculate_metrics(y_train, y_pred_train)
+            mae_test, rmse_test, r2_test, p_test = self.calculate_metrics(y_test, y_pred_test)
+            best_model = self.model.best_model()["learner"]
+            best_preprocessing = self.model.best_model()["preprocs"]
+            # Evaluate on test set
             pipe = [(f"preproc_{i}", preproc) for i, preproc in enumerate(best_preprocessing)]
             pipe.append(("model", best_model))
+
             self.pipeline = pipeline.Pipeline(pipe)
-            
-            print("Hyperoptimization best parameters:\n"
-                  f"\t- Best preprocessing:\n\t\t{best_preprocessing}\n"
-                  f"\t- Best model:\n\t\t{best_model}")
-        else:
-            print("No hyperparameter optimization was performed.")
-
-        # Apply cross-validation
-        kf = model_selection.KFold(n_splits=self.CV_split, random_state=self.seed, shuffle=True)
-        for i, (train, test) in enumerate(kf.split(X)):
-            X_train, X_test = X[train], X[test]
-            y_train, y_test = y[train], y[test]
-
-            # Train model
-            self.pipeline.fit(X_train, y_train)
-
-            # Predictions
-            y_pred_train = self.pipeline.predict(X_train)
-            y_pred_test = self.pipeline.predict(X_test)
-
-            # Metrics
-            print("Fold N: %d" % (i + 1))
-            metrics_train.append(self.calculate_metrics(y_train, y_pred_train))
-            print("Train: MAE %.2f, RMSE %.2f, R2 %.3f, p %.3f" % metrics_train[i])
-            metrics_test.append(self.calculate_metrics(y_test, y_pred_test))
-            print("Test: MAE %.2f, RMSE %.2f, R2 %.3f, p %.3f" % metrics_test[i])
+            print(f"Train: MAE {mae_train:.2f}, RMSE {rmse_train:.2f}, R2 {r2_train:.3f}, p {p_train:.3f}")
+            print(f"Test: MAE {mae_test:.2f}, RMSE {rmse_test:.2f}, R2 {r2_test:.3f}, p {p_test:.3f}")
+            print(
+                "Hyperoptimization best parameters:\n"
+                f"\t- Best preprocessing:\n\t\t{best_preprocessing}\n"
+                f"\t- Best model:\n\t\t{best_model}"
+            )
 
             # Fit and apply age-bias correction
             self.fit_age_bias(y_train, y_pred_train)
             y_pred_test_no_bias = self.predict_age_bias(y_test, y_pred_test)
-
             # Save results of hold out
-            pred_age[test] = y_pred_test
-            corrected_age[test] = y_pred_test_no_bias
+            pred_age[self.test_indices] = y_pred_test
+            corrected_age[self.test_indices] = y_pred_test_no_bias
 
-        # Calculate metrics over all splits
-        print("Summary metrics over all CV splits")
-        summary_train = self.summary_metrics(metrics_train)
-        print("Train: MAE %.2f ± %.2f, RMSE %.2f ± %.2f, R2 %.3f ± %.3f, p %.3f ± %.3f" % tuple(summary_train))
-        summary_test = self.summary_metrics(metrics_test)
-        print("Test: MAE %.2f ± %.2f, RMSE %.2f ± %.2f, R2 %.3f ± %.3f, p %.3f ± %.3f" % tuple(summary_test))
         # Print comparison with mean age as only predictor to have a reference of a dummy regressor
         dummy_rmse = np.sqrt(np.mean((y - np.mean(y)) ** 2))
         dummy_mae = np.mean(np.abs(y - np.mean(y)))
         print(
-            "When using mean of ages as predictor for each subject (dummy regressor):\n" "MAE: %.2f, RMSE: %.2f" % (dummy_mae, dummy_rmse)
+            "\nWhen using mean of ages as predictor for each subject (dummy regressor):\n" "MAE: %.2f, RMSE: %.2f" % (dummy_mae, dummy_rmse)
         )
         print("Age range: %.2f" % (np.max(y) - np.min(y)))
 
@@ -505,7 +527,6 @@ class AgeML:
 
 
 class Classifier:
-
     """Classifier of class labels based on deltas.
 
     This class allows the differentiation of two groups based

--- a/src/ageml/modelling.py
+++ b/src/ageml/modelling.py
@@ -414,11 +414,6 @@ class AgeML:
                     split_metrics_train.append(self.calculate_metrics(y_train, y_pred_train))
                     split_metrics_test.append(self.calculate_metrics(y_test, y_pred_test))
 
-                    # Print metrics
-                    print("\nFold N: %d" % (i + 1))
-                    print("Train: MAE %.2f, RMSE %.2f, R2 %.3f, p %.3f" % split_metrics_train[i])
-                    print("Test: MAE %.2f, RMSE %.2f, R2 %.3f, p %.3f" % split_metrics_test[i])
-
                     # Fit and apply age-bias correction
                     self.fit_age_bias(y_train, y_pred_train)
                     y_pred_test_no_bias = self.predict_age_bias(y_test, y_pred_test)
@@ -436,13 +431,8 @@ class AgeML:
                     best_split_mae = mean_score_test
                     pred_age = copy.deepcopy(temp_pred_age)
                     corrected_age = copy.deepcopy(temp_corr_age)
-
-                # CV Summary of the selected hyperparameters
-                print("\nSummary metrics over all CV splits:")
-                summary_train = self.summary_metrics(split_metrics_train)
-                print("Train: MAE %.2f ± %.2f, RMSE %.2f ± %.2f, R2 %.3f ± %.3f, p %.3f ± %.3f" % tuple(summary_train))
-                summary_test = self.summary_metrics(split_metrics_test)
-                print("Test: MAE %.2f ± %.2f, RMSE %.2f ± %.2f, R2 %.3f ± %.3f, p %.3f ± %.3f" % tuple(summary_test))
+                    best_split_metrics_train = copy.deepcopy(split_metrics_train)
+                    best_split_metrics_test = copy.deepcopy(split_metrics_test)
 
             # Select the best pipeline based on the mean scores
             best_hyperparam_index = np.argmin(mae_means_test)
@@ -451,6 +441,13 @@ class AgeML:
             if self.hyperparameter_tuning > 0:
                 print(f"\nHyperoptimization best parameters: {hyperparameter_grid[best_hyperparam_index]}")
                 print(f"Best pipeline:\n{self.pipeline}")
+
+            # CV Summary of the selected hyperparameters
+            print("\nSummary metrics of the best CV split for the best hyperparameters:")
+            summary_train = self.summary_metrics(best_split_metrics_train)
+            print("Train: MAE %.2f ± %.2f, RMSE %.2f ± %.2f, R2 %.3f ± %.3f, p %.3f ± %.3f" % tuple(summary_train))
+            summary_test = self.summary_metrics(best_split_metrics_test)
+            print("Test: MAE %.2f ± %.2f, RMSE %.2f ± %.2f, R2 %.3f ± %.3f, p %.3f ± %.3f" % tuple(summary_test))
 
         elif self.model_type == "hyperopt":
             print("Running Hyperparameter optimization with 'hyperopt' model option...")

--- a/src/ageml/ui.py
+++ b/src/ageml/ui.py
@@ -1797,7 +1797,7 @@ class CLI(Interface):
         print("Polynomial feature extension degree. Leave blank if not desired (Default: 0, max. 3)")
         print("Example: 3")
         self.force_command(self.feature_extension_command)
-        print("Hyperparameter tuning. Number of points in grid search: (Default: 0)")
+        print("Hyperparameter tuning. Number of points in grid search: (Default: 2)")
         print("Example: 100")
         self.force_command(self.hyperparameter_grid_command)
         print("Hyperparameters to tune. Leave blank if not desired (Default: None)")
@@ -1997,11 +1997,21 @@ class CLI(Interface):
                 if item.count("=") != 1:
                     error = (
                         "Hyperparameter tuning parameters must be in the format "
-                        "param1=value1_low,value1_high param2=value2_low, value2_high..."
+                        "param1=value1_low,value1_high param2=kernel_A,kernel_B,kernel_C..."
                     )
                     return error
-                key, value = item.split("=")
-                low, high = value.split(",")
-                hyperparameter_params[key] = [convert(low), convert(high)]
+                key, values = item.split("=")
+                values = [convert(value) for value in values.split(",")]
+                vals_are_str = all([isinstance(value, str) for value in values])
+                vals_are_num = all([isinstance(value, (int, float)) for value in values])
+                # If not 2 values provided in numerical hyperparams, raise error
+                if vals_are_num and len(values) != 2:
+                    err_msg = "Numerical hyperparameter values must be exactly two numbers (e.g.: param1=2,3)."
+                    raise ValueError(err_msg)
+                # If no value provided in categorical hyperparams, raise error
+                elif vals_are_str and len(values) < 1:
+                    err_msg = "Categorical hyperparameter values must be at least one string (e.g.: param1=kernel_A)."
+                    raise ValueError(err_msg)
+                hyperparameter_params[key] = values
             # Add attribute to args
             self.args.hyperparameter_params = hyperparameter_params

--- a/tests/test_ageml/test_ui.py
+++ b/tests/test_ageml/test_ui.py
@@ -10,8 +10,6 @@ import numpy as np
 import ageml.messages as messages
 from ageml.ui import Interface, CLI, AgeML
 
-
-# RNG for reproducibility
 seed = 107146869338163146621163044826586732901
 rng = np.random.default_rng(seed)
 
@@ -20,7 +18,7 @@ class ExampleArguments(object):
     def __init__(self):
         self.scaler_type = "standard"
         self.scaler_params = {"with_mean": True}
-        self.model_type = "linear_reg"
+        self.model_type = "ridge"
         self.model_params = {"fit_intercept": True}
         self.model_cv_split = 2
         self.model_seed = 0
@@ -40,6 +38,7 @@ class ExampleArguments(object):
         self.group1 = None
         self.group2 = None
         self.hyperparameter_tuning = 0
+        self.hyperparameter_params = "alpha=-3,3"
         self.feature_extension = 0
 
 
@@ -1461,7 +1460,7 @@ def test_model_age_command_CLI(dummy_cli, features, monkeypatch, capsys):
     features_path = create_csv(features, tempDir.name)
 
     # Test command
-    responses = ["model_age", features_path, "", "", "", "", "", "", "", "", "", "q"]
+    responses = ["model_age", features_path, "", "", "", "", "", "", "", "", "", "", "q"]
     monkeypatch.setattr("builtins.input", lambda _: responses.pop(0))
     dummy_cli.command_interface()
     captured = capsys.readouterr().out.split("\n")[:-1]
@@ -1481,6 +1480,7 @@ def test_model_age_command_CLI(dummy_cli, features, monkeypatch, capsys):
         "",
         "",
         "",
+        "",
         "q",
     ]
     monkeypatch.setattr("builtins.input", lambda _: responses.pop(0))
@@ -1493,15 +1493,16 @@ def test_model_age_command_CLI(dummy_cli, features, monkeypatch, capsys):
     responses = [
         "model_age",
         features_path,
-        "",
-        "",
-        "",
-        "",
-        "",
-        "linear_svr",
-        "",
-        "2",
-        "3",
+        "",  # covariates
+        "",  # covariate name
+        "",  # clinical
+        "",  # systems
+        "",  # scaler
+        "linear_svr",  # model
+        "",  # CrossVal params
+        "2",  # Polynomial feature extension
+        "3",  # Hyperparameter tuning
+        "epsilon=-3,3",
         "",
         "q",
     ]


### PR DESCRIPTION
# Summary
Users can now specify which parameters of the selected model can be hyperoptimized for. This way, for models with many hyperparameters, the search space is reduced a lot, whereas previously we would train $n^g$ models ($n:$ number of model parameters, $g:$ Hyperparameter grid points). Also fixes double-dipping problems in model fitting.

## Key Changes
- Addition of selection of hyperparameters to optimize in the CLI and its interactive version.
- the `hyperopt` model now trains on a dataset split instead of CV due to `hyperopt-sklearn` library limitations. The testing set indices for each model (dependent on covariates and systems) are returned in CSV files under the `ageml/model_age` directory.
- `AgeML.fit_age` method now has 2 train cases instead of 3, making it more concise and efficient.
- Modified the help message of the `-ht` argument.
- Adapted tests of interactive CLI for the new hyperparameter selection.

### Other changes
- Minor typo corrections
- `rng` from the `ageml.datasets` module is used in the `ui` module to do a index random permutation, instead of using `np.random`, which is discouraged
- MAE $\rightarrow$ mae